### PR TITLE
fix link to examples directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,5 @@ $response = $lnPayClient->lightingNetworkTx->getInfo('lntx_id');
 print_r($response);
 ```
 
-See this [example files]().
+See this [example files](examples).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The first alpha version of this SDK is mainly a wrapper for the [LNPay API](http
 // Load the autoload file from composer's vendor directory
 require '../vendor/autoload.php';
 
-use LNPay\LNPayClient;
+use LNPayClient\LNPayClient;
 
 // Creating Client object
 $lnPayClient = new LNPayClient(
@@ -49,7 +49,7 @@ $lnPayClient = new LNPayClient(
 
 require 'init.php';
 
-use LNPay\LNPayClient;
+use LNPayClient\LNPayClient;
 
 // Creating Client object
 $lnPayClient = new LNPayClient(
@@ -60,7 +60,7 @@ $lnPayClient = new LNPayClient(
 ```
 // Wallet Access Key setup if not added while LNPayClient object creationation.
 
-$lnPayClient->wallet->setWalletAccessKey('wal_KEY')
+$lnPayClient->wallet->setWalletAccessKey('wal_KEY');
 ```
 
 ## Usage
@@ -92,7 +92,7 @@ print_r($response);
 ### Pay Invoice
 ```
 $response = $lnPayClient->wallet->payInvoice(array(
-        "payment_request" => "2"
+        "payment_request" => "lnXXXX"
     ));
 print_r($response);
 ```
@@ -118,5 +118,5 @@ $response = $lnPayClient->lightingNetworkTx->getInfo('lntx_id');
 print_r($response);
 ```
 
-See this [example files](examples).
+See the [example files](examples).
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,7 @@
     <php>
         <!-- copy this file to phpunit.xml and replace with your API key to run tests -->
         <!--
-        <server name="PUBLIC_API_KEY" value="sak_XXXX" />
+        <server name="PUBLIC_API_KEY" value="sak_KEY" />
         -->
     </php>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,8 @@
 
     <php>
         <!-- copy this file to phpunit.xml and replace with your API key to run tests -->
-        <!-- Also uncomment the following two lines-->
-        <!--<server name="KEY_ID" value="" />
-        <server name="KEY_SECRET" value="" />
+        <!--
+        <server name="PUBLIC_API_KEY" value="sak_XXXX" />
         -->
     </php>
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -66,7 +66,7 @@ class Request
     protected function post(string $uri, array $params = [], float $timeOut = 2.0)
     {
         $client = new Client([
-            'base_uri' => LNPayClient::getFullUrl($uri),
+            'base_uri' => LNPayClient::getEndPointUrl(),
             'timeout' => $timeOut,
         ]);
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -23,7 +23,7 @@ class RequestTest extends TestCase
     {
         parent::setUp();
         $lnPayClient = new LNPayClient(
-            'sak_<KEY>',
+            $_SERVER['PUBLIC_API_KEY'],
         );
 
         $this->request = new Request();


### PR DESCRIPTION
currently link to examples returns a 404 (https://github.com/lnpay/lnpay-php/blob/master), this pull request links to the actual examples directory 